### PR TITLE
Fix encoding error

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -126,11 +126,12 @@ defmodule SweetXml do
 
   Return an `xmlElement` record
   """
-  def parse(doc) when is_binary(doc) do
-    doc |> :erlang.binary_to_list |> parse
+  def parse(doc), do: parse(doc,[])
+  def parse(doc,options) when is_binary(doc) do
+    doc |> :erlang.binary_to_list |> parse(options)
   end
-  def parse(doc) do
-    {parsed_doc, _} = :xmerl_scan.string(doc)
+  def parse(doc,options) do
+    {parsed_doc, _} = :xmerl_scan.string(doc,options)
     parsed_doc
   end
 

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -121,13 +121,13 @@ defmodule SweetXml do
   end
 
   @doc """
-  `doc` can be a char_list or string, but ultimately converts to char_list as it
-  is required by :xmerl_scan
+  `doc` can be a byte list (iodata) or binary, but ultimately converts to iodata as it
+  is required by :xmerl_scan (xmerl takes care of the encoding and convert txt to char_data).
 
   Return an `xmlElement` record
   """
-  def parse(doc) when is_bitstring(doc) do
-    doc |> String.to_char_list |> parse
+  def parse(doc) when is_binary(doc) do
+    doc |> :erlang.binary_to_list |> parse
   end
   def parse(doc) do
     {parsed_doc, _} = :xmerl_scan.string(doc)

--- a/test/files/simple.xml
+++ b/test/files/simple.xml
@@ -4,7 +4,7 @@
     <title>XML Parsing</title>
   </head>
   <body>
-    <p>Neato</p>
+    <p>Neato €</p>
     <ul>
       <li class="first star" data-index="1">First</li>
       <li class="second">Second</li>

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -280,7 +280,7 @@ defmodule SweetXmlTest do
     assert result == %{
       html: %{
         body: %{
-          p: 'Neato',
+          p: 'Neato €',
           first_list: [
             %{class: 'first star', data_attr: nil, text: 'First'},
             %{class: 'second', data_attr: nil, text: 'Second'},


### PR DESCRIPTION
Hello,

Actually I have developed exactly the same wrapper around `xmerl`, but since you already published this on hex.pm and sweet_xml has users, I will pull request you the additional features.

This pull request is a fix to begin.

- xmerl handles iodata (list of integer from 0 to 255), read encoding in
  the xml file or options and convert texts into char_data (list of
  integer, one for each char)
- use :erlang.binary_to_list since it is 10x faster than bit
  comprehension for instance

I updated the tests adding an '€' symbol, which is a sufficient test.

