### PR TITLE
Stream feature

### DIFF
--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -126,11 +126,12 @@ defmodule SweetXml do
 
   Return an `xmlElement` record
   """
-  def parse(doc) when is_binary(doc) do
-    doc |> :erlang.binary_to_list |> parse
+  def parse(doc), do: parse(doc,[])
+  def parse(doc,options) when is_binary(doc) do
+    doc |> :erlang.binary_to_list |> parse(options)
   end
-  def parse(doc) do
-    {parsed_doc, _} = :xmerl_scan.string(doc)
+  def parse(doc,options) do
+    {parsed_doc, _} = :xmerl_scan.string(doc,options)
     parsed_doc
   end
 

--- a/lib/sweet_xml.ex
+++ b/lib/sweet_xml.ex
@@ -121,13 +121,13 @@ defmodule SweetXml do
   end
 
   @doc """
-  `doc` can be a char_list or string, but ultimately converts to char_list as it
-  is required by :xmerl_scan
+  `doc` can be a byte list (iodata) or binary, but ultimately converts to iodata as it
+  is required by :xmerl_scan (xmerl takes care of the encoding and convert txt to char_data).
 
   Return an `xmlElement` record
   """
-  def parse(doc) when is_bitstring(doc) do
-    doc |> String.to_char_list |> parse
+  def parse(doc) when is_binary(doc) do
+    doc |> :erlang.binary_to_list |> parse
   end
   def parse(doc) do
     {parsed_doc, _} = :xmerl_scan.string(doc)

--- a/test/files/simple.xml
+++ b/test/files/simple.xml
@@ -4,7 +4,7 @@
     <title>XML Parsing</title>
   </head>
   <body>
-    <p>Neato</p>
+    <p>Neato €</p>
     <ul>
       <li class="first star" data-index="1">First</li>
       <li class="second">Second</li>

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -280,7 +280,7 @@ defmodule SweetXmlTest do
     assert result == %{
       html: %{
         body: %{
-          p: 'Neato',
+          p: 'Neato €',
           first_list: [
             %{class: 'first star', data_attr: nil, text: 'First'},
             %{class: 'second', data_attr: nil, text: 'Second'},

--- a/test/sweet_xml_test.exs
+++ b/test/sweet_xml_test.exs
@@ -7,13 +7,19 @@ defmodule SweetXmlTest do
   setup do
     simple = File.read!("./test/files/simple.xml")
     complex = File.read!("./test/files/complex.xml")
+    complex_stream = File.stream!("./test/files/complex.xml",[:raw])
     readme = File.read!("test/files/readme.xml")
-    {:ok, [simple: simple, complex: complex, readme: readme]}
+    {:ok, [simple: simple, complex: complex, complex_stream: complex_stream, readme: readme]}
   end
 
   test "parse", %{simple: doc} do
     result = doc |> parse
     assert xmlElement(result, :name) == :html
+  end
+
+  test "parse stream", %{complex_stream: stream} do
+    result = stream |> parse
+    assert xmlElement(result, :name) == :fantasy_content
   end
 
   test "xpath sigil" do


### PR DESCRIPTION
Hello Again,
Features in this pull request allows you to use Elixir streams in both side : Xml producer and consumer. When used for both, the production of binaries is triggered by the enumeration of produced elements.

- `parse` can now take any enumerable of binaries, for instance a `File.stream!` to read the file step by step.
- A generic function `stream`, allows you to create any element stream from the xml, using custom xmerl callbacks.
- A function `stream_tags` use `stream` to allow a standard usage in XML parsing : read some element  by tag but during DOM construction, omit some other elements by tag to free memory during the process, a very good replacement for SAX since you can stream partial DOMs and forget them.

I use this piece of code for some time now and it works well, I parse 10Gb XML files in streaming and take advantage of the DOM of each streamed elements with Xpath. 

Have a nice evening
